### PR TITLE
Add closing tag to native canvas

### DIFF
--- a/web/docs/index.html
+++ b/web/docs/index.html
@@ -81,7 +81,7 @@ process.<span class="property">stdout</span>.<span class="method">write</span>(c
               using CSS:
             </p>
             <pre>
-&lt;<span class="value">canvas</span> <span class="property">id</span>=<span class="string">"my-canvas"</span> /&gt;
+&lt;<span class="value">canvas</span> <span class="property">id</span>=<span class="string">"my-canvas"</span>&gt;&lt;<span class="value">/canvas</span>&gt;
 
 &lt;<span class="value">script</span> <span class="property">type</span>=<span class="string">"module"</span>&gt;
   <span class="keyword">import</span> { generate } <span class="keyword">from</span> <span class="string">'lean-qr'</span>;


### PR DESCRIPTION
I noticed the self-closing slash in the browser native example:

```html
<canvas id="my-canvas" />
```

Unfortunately, the slash doesn’t close anything in browsers. They ignore it as a syntactical error. For non-self-closing elements, the tag is still open. It can lead to confusion or even serious mistakes, since this markup:

```html
<canvas />
<p>Hello</p>
```

…will lead to all the following content being swallowed:

```html
<canvas>
  <p>Hello</p>
</canvas>
```

So I’m suggesting showing it like this:

```html
<canvas id="my-canvas"></canvas>
```